### PR TITLE
fix(configurations): Extend version-specific configurations form its shared equivalent

### DIFF
--- a/samples/basic/groovy/build.gradle
+++ b/samples/basic/groovy/build.gradle
@@ -25,6 +25,10 @@ repositories {
 }
 
 dependencies {
+    compileOnly "org.projectlombok:lombok:1.18.30"
+	annotationProcessor "org.projectlombok:lombok:1.18.30"
+    implementation "org.apache.commons:commons-lang3:3.13.0"
+
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
 }
 

--- a/samples/basic/groovy/src/main/java/demo/app/Libs.java
+++ b/samples/basic/groovy/src/main/java/demo/app/Libs.java
@@ -1,0 +1,14 @@
+package demo.app;
+
+import org.apache.commons.lang3.StringUtils;
+import lombok.Value;
+
+@Value
+public class Libs {
+
+  private String greet;
+
+  public static String sharedLib() {
+    return StringUtils.EMPTY;
+  }
+}

--- a/samples/basic/groovy/src/main/java11/demo/app/Libs.java
+++ b/samples/basic/groovy/src/main/java11/demo/app/Libs.java
@@ -1,0 +1,16 @@
+package demo.app;
+
+import org.apache.commons.lang3.StringUtils;
+import lombok.Value;
+
+@Value
+public class Libs {
+
+  private String greet;
+
+  public static String sharedLib() {
+    final var empty = StringUtils.EMPTY; // to simulate Java 11 specific
+
+    return empty;
+  }
+}

--- a/samples/basic/groovy/src/test/java/demo/app/LibsTest.java
+++ b/samples/basic/groovy/src/test/java/demo/app/LibsTest.java
@@ -1,0 +1,19 @@
+package demo.app;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LibsTest {
+
+  @Test void sharedLib() {
+    Libs libs = new Libs("Hello world!");
+
+    assertEquals(libs.sharedLib(), "");
+  }
+
+  @Test void getGreet() {
+    Libs libs = new Libs("Hello world!");
+
+    assertEquals(libs.getGreet(), "Hello world!");
+  }
+}

--- a/samples/basic/kotlin/build.gradle.kts
+++ b/samples/basic/kotlin/build.gradle.kts
@@ -25,6 +25,10 @@ repositories {
 }
 
 dependencies {
+    compileOnly("org.projectlombok:lombok:1.18.30")
+	annotationProcessor("org.projectlombok:lombok:1.18.30")
+    implementation("org.apache.commons:commons-lang3:3.13.0")
+
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
 }
 

--- a/samples/basic/kotlin/src/main/java/demo/app/Libs.java
+++ b/samples/basic/kotlin/src/main/java/demo/app/Libs.java
@@ -1,0 +1,14 @@
+package demo.app;
+
+import org.apache.commons.lang3.StringUtils;
+import lombok.Value;
+
+@Value
+public class Libs {
+
+  private String greet;
+
+  public static String sharedLib() {
+    return StringUtils.EMPTY;
+  }
+}

--- a/samples/basic/kotlin/src/main/java11/demo/app/Libs.java
+++ b/samples/basic/kotlin/src/main/java11/demo/app/Libs.java
@@ -1,0 +1,16 @@
+package demo.app;
+
+import org.apache.commons.lang3.StringUtils;
+import lombok.Value;
+
+@Value
+public class Libs {
+
+  private String greet;
+
+  public static String sharedLib() {
+    final var empty = StringUtils.EMPTY; // to simulate Java 11 specific
+
+    return empty;
+  }
+}

--- a/samples/basic/kotlin/src/test/java/demo/app/LibsTest.java
+++ b/samples/basic/kotlin/src/test/java/demo/app/LibsTest.java
@@ -1,0 +1,19 @@
+package demo.app;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LibsTest {
+
+  @Test void sharedLib() {
+    Libs libs = new Libs("Hello world!");
+
+    assertEquals(libs.sharedLib(), "");
+  }
+
+  @Test void getGreet() {
+    Libs libs = new Libs("Hello world!");
+
+    assertEquals(libs.getGreet(), "Hello world!");
+  }
+}


### PR DESCRIPTION
This PR fixes #3 by extending each version-specific configuration from its shared equivalent configuration. It also adds a few tests using different configurations: `implementation`, `compileOnly`, and `annotationProcessor`. Test configurations are also included, so there's no need to explicitly extend those anymore.