### PR TITLE
Improved toolchains support & fix to configurations

### DIFF
--- a/plugin/src/main/java/me/champeau/mrjar/MultiReleaseExtension.java
+++ b/plugin/src/main/java/me/champeau/mrjar/MultiReleaseExtension.java
@@ -28,6 +28,7 @@ import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.PluginManager;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
@@ -43,6 +44,8 @@ import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 
 public abstract class MultiReleaseExtension {
@@ -55,6 +58,7 @@ public abstract class MultiReleaseExtension {
     private final JavaToolchainService javaToolchains;
     private final PluginManager pluginManager;
     private final ExtensionContainer extensions;
+    private final Property<Boolean> sharedToolchain;
 
     @Inject
     public MultiReleaseExtension(JavaPluginExtension javaPluginExtension,
@@ -75,13 +79,15 @@ public abstract class MultiReleaseExtension {
         this.objects = objectFactory;
         this.pluginManager = pluginManager;
         this.extensions = extensions;
+        this.sharedToolchain = objects.property(Boolean.class);
     }
 
 
     public void targetVersions(String mainSourceDirectory, String testSourceDirectory, int defaultVersion, int... versions) {
-        defaultLanguageVersion(defaultVersion);
+        int maxVersion = Arrays.stream(versions).max().getAsInt();
+        defaultLanguageVersion(maxVersion, defaultVersion);
         for (int version : versions) {
-            addLanguageVersion(version, mainSourceDirectory, testSourceDirectory);
+            addLanguageVersion(maxVersion, version, mainSourceDirectory, testSourceDirectory);
         }
     }
 
@@ -93,7 +99,7 @@ public abstract class MultiReleaseExtension {
         targetVersions(sourceDirectory + "main/", sourceDirectory + "test/", defaultVersion, versions);
     }
 
-    private void addLanguageVersion(int version, String mainSourceDirectory, String testSourceDirectory) {
+    private void addLanguageVersion(int maxVersion, int version, String mainSourceDirectory, String testSourceDirectory) {
         String javaX = "java" + version;
         // First, let's create a source set for this language version
         SourceSet langSourceSet = sourceSets.create(javaX, srcSet -> srcSet.getJava().srcDir(mainSourceDirectory + javaX));
@@ -111,16 +117,23 @@ public abstract class MultiReleaseExtension {
         dependencies.add(javaX + "Implementation", mainClasses);
 
         // then configure the compile task so that it uses the expected Gradle version
-        Provider<JavaCompiler> targetCompiler = javaToolchains.compilerFor(spec -> spec.getLanguageVersion().convention(JavaLanguageVersion.of(version)));
-        tasks.named(langSourceSet.getCompileJavaTaskName(), JavaCompile.class, task ->
-                task.getJavaCompiler().convention(targetCompiler)
-        );
-        tasks.named(testSourceSet.getCompileJavaTaskName(), JavaCompile.class, task ->
-                task.getJavaCompiler().convention(targetCompiler)
-        );
+        JavaLanguageVersion jlv = JavaLanguageVersion.of(isUseSharedToolchain() ? maxVersion : version);
+        Provider<JavaCompiler> targetCompiler = javaToolchains.compilerFor(spec -> spec.getLanguageVersion().convention(jlv));
+        tasks.named(langSourceSet.getCompileJavaTaskName(), JavaCompile.class, task -> {
+                task.getJavaCompiler().convention(targetCompiler);
+                if (isUseSharedToolchain()) {
+                  task.getOptions().getRelease().convention(version);
+                }
+        });
+        tasks.named(testSourceSet.getCompileJavaTaskName(), JavaCompile.class, task -> {
+                task.getJavaCompiler().convention(targetCompiler);
+                if (isUseSharedToolchain()) {
+                  task.getOptions().getRelease().convention(version);
+                }
+        });
 
         // let's make sure to create a "test" task
-        Provider<JavaLauncher> targetLauncher = javaToolchains.launcherFor(spec -> spec.getLanguageVersion().convention(JavaLanguageVersion.of(version)));
+        Provider<JavaLauncher> targetLauncher = javaToolchains.launcherFor(spec -> spec.getLanguageVersion().convention(jlv));
 
         Configuration testImplementation = configurations.getByName(testSourceSet.getImplementationConfigurationName());
         testImplementation.extendsFrom(configurations.getByName(sharedTestSourceSet.getImplementationConfigurationName()));
@@ -179,7 +192,26 @@ public abstract class MultiReleaseExtension {
         });
     }
 
-    private void defaultLanguageVersion(int version) {
-        javaPluginExtension.getToolchain().getLanguageVersion().convention(JavaLanguageVersion.of(version));
+    private void defaultLanguageVersion(int maxVersion, int version) {
+        JavaLanguageVersion jlv = JavaLanguageVersion.of(isUseSharedToolchain() ? maxVersion : version);
+        javaPluginExtension.getToolchain().getLanguageVersion().convention(jlv);
+        // Set release for main/test compile tasks if using shared toolchain
+        if (isUseSharedToolchain()) {
+          Stream.of(SourceSet.MAIN_SOURCE_SET_NAME, SourceSet.TEST_SOURCE_SET_NAME)
+                  .map(ssn -> sourceSets.named(ssn, SourceSet.class).get())
+                  .map(ss -> ss.getCompileJavaTaskName())
+                  .forEach(taskName -> {
+                    tasks.named(taskName, JavaCompile.class, task -> {
+                        task.getOptions().getRelease().set(version);
+                    });
+                  });
+        }
+    }
+
+    public void sharedToolchain(boolean useSharedToolchain) {
+        sharedToolchain.set(useSharedToolchain);
+    }
+    private boolean isUseSharedToolchain() {
+        return sharedToolchain.isPresent() && sharedToolchain.get();
     }
 }

--- a/plugin/src/main/java/me/champeau/mrjar/MultiReleaseExtension.java
+++ b/plugin/src/main/java/me/champeau/mrjar/MultiReleaseExtension.java
@@ -22,6 +22,8 @@ import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ApplicationPlugin;
 import org.gradle.api.plugins.ExtensionContainer;
@@ -45,6 +47,8 @@ import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 
@@ -59,6 +63,7 @@ public abstract class MultiReleaseExtension {
     private final PluginManager pluginManager;
     private final ExtensionContainer extensions;
     private final Property<Boolean> sharedToolchain;
+    private final Logger logger;
 
     @Inject
     public MultiReleaseExtension(JavaPluginExtension javaPluginExtension,
@@ -80,6 +85,7 @@ public abstract class MultiReleaseExtension {
         this.pluginManager = pluginManager;
         this.extensions = extensions;
         this.sharedToolchain = objects.property(Boolean.class);
+        this.logger = Logging.getLogger(MultiReleaseJarPlugin.class);
     }
 
 
@@ -100,6 +106,7 @@ public abstract class MultiReleaseExtension {
     }
 
     private void addLanguageVersion(int maxVersion, int version, String mainSourceDirectory, String testSourceDirectory) {
+        logger.info("Configuring multi-release support for Java {}", version);
         String javaX = "java" + version;
         // First, let's create a source set for this language version
         SourceSet langSourceSet = sourceSets.create(javaX, srcSet -> srcSet.getJava().srcDir(mainSourceDirectory + javaX));
@@ -118,22 +125,26 @@ public abstract class MultiReleaseExtension {
 
         // then configure the compile task so that it uses the expected Gradle version
         JavaLanguageVersion jlv = JavaLanguageVersion.of(isUseSharedToolchain() ? maxVersion : version);
+        logger.info("Setting JavaCompile toolchain for Java {}: {}", version, jlv);
         Provider<JavaCompiler> targetCompiler = javaToolchains.compilerFor(spec -> spec.getLanguageVersion().convention(jlv));
         tasks.named(langSourceSet.getCompileJavaTaskName(), JavaCompile.class, task -> {
                 task.getJavaCompiler().convention(targetCompiler);
                 if (isUseSharedToolchain()) {
+                  logger.info("Setting release version {} for JavaCompile task '{}'", version, task.getName());
                   task.getOptions().getRelease().convention(version);
                 }
         });
         tasks.named(testSourceSet.getCompileJavaTaskName(), JavaCompile.class, task -> {
                 task.getJavaCompiler().convention(targetCompiler);
                 if (isUseSharedToolchain()) {
+                  logger.info("Setting release version {} for JavaCompile task '{}'", version, task.getName());
                   task.getOptions().getRelease().convention(version);
                 }
         });
 
         // let's make sure to create a "test" task
         Provider<JavaLauncher> targetLauncher = javaToolchains.launcherFor(spec -> spec.getLanguageVersion().convention(jlv));
+        logger.info("Setting JavaLauncher toolchain for Java {}: {}", version, jlv);
 
         Configuration testImplementation = configurations.getByName(testSourceSet.getImplementationConfigurationName());
         testImplementation.extendsFrom(configurations.getByName(sharedTestSourceSet.getImplementationConfigurationName()));
@@ -186,6 +197,7 @@ public abstract class MultiReleaseExtension {
 
     private void configureMrJar(int version, SourceSet languageSourceSet) {
         tasks.named("jar", Jar.class, jar -> {
+            logger.info("Configuring Jar task for Java version: {}", version);
             jar.into("META-INF/versions/" + version, s -> s.from(languageSourceSet.getOutput()));
             Attributes attributes = jar.getManifest().getAttributes();
             attributes.put("Multi-Release", "true");
@@ -194,6 +206,7 @@ public abstract class MultiReleaseExtension {
 
     private void defaultLanguageVersion(int maxVersion, int version) {
         JavaLanguageVersion jlv = JavaLanguageVersion.of(isUseSharedToolchain() ? maxVersion : version);
+        logger.info("Setting default Java version: {}", jlv);
         javaPluginExtension.getToolchain().getLanguageVersion().convention(jlv);
         // Set release for main/test compile tasks if using shared toolchain
         if (isUseSharedToolchain()) {
@@ -201,6 +214,7 @@ public abstract class MultiReleaseExtension {
                   .map(ssn -> sourceSets.named(ssn, SourceSet.class).get())
                   .map(ss -> ss.getCompileJavaTaskName())
                   .forEach(taskName -> {
+                    logger.info("Setting release version {} for JavaCompile task '{}'", version, taskName);
                     tasks.named(taskName, JavaCompile.class, task -> {
                         task.getOptions().getRelease().set(version);
                     });
@@ -209,6 +223,7 @@ public abstract class MultiReleaseExtension {
     }
 
     public void sharedToolchain(boolean useSharedToolchain) {
+        logger.info("Setting shared Java toolchain");
         sharedToolchain.set(useSharedToolchain);
     }
     private boolean isUseSharedToolchain() {

--- a/plugin/src/main/java/me/champeau/mrjar/MultiReleaseExtension.java
+++ b/plugin/src/main/java/me/champeau/mrjar/MultiReleaseExtension.java
@@ -46,6 +46,8 @@ import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
+import groovy.lang.Tuple;
+import groovy.lang.Tuple2;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
@@ -92,6 +94,7 @@ public abstract class MultiReleaseExtension {
     public void targetVersions(String mainSourceDirectory, String testSourceDirectory, int defaultVersion, int... versions) {
         int maxVersion = Arrays.stream(versions).max().getAsInt();
         defaultLanguageVersion(maxVersion, defaultVersion);
+        Arrays.sort(versions);
         for (int version : versions) {
             addLanguageVersion(maxVersion, version, mainSourceDirectory, testSourceDirectory);
         }
@@ -113,6 +116,28 @@ public abstract class MultiReleaseExtension {
         SourceSet testSourceSet = sourceSets.create(javaX + "Test", srcSet -> srcSet.getJava().srcDir(testSourceDirectory + javaX));
         SourceSet sharedSourceSet = sourceSets.findByName(SourceSet.MAIN_SOURCE_SET_NAME);
         SourceSet sharedTestSourceSet = sourceSets.findByName(SourceSet.TEST_SOURCE_SET_NAME);
+
+        // Any javaX configuration should extend from similar configuration of closest lower version
+        configurations.matching(config -> config.getName().startsWith(javaX)).configureEach(specific -> {
+            String noPrefix = specific.getName().replace(javaX, "");
+            // Find closest lower version configuration
+            Optional<Configuration> cc = configurations.matching(c -> c.getName().matches("java\\d+" + noPrefix)).stream()
+                    .map(c -> Tuple.tuple(c, Integer.valueOf(c.getName().replace("java", "").replace(noPrefix, ""))))
+                    .filter(t -> t.getV2() < version)
+                    .sorted(Comparator.<Tuple2<Configuration, Integer>>comparingInt(Tuple2::getV2).reversed())
+                    .map(t -> t.getV1()).findFirst();
+            if (cc.isPresent()) {
+                logger.info("Setting configuration '{}' extendsFrom '{}'", specific.getName(), cc.get().getName());
+                specific.extendsFrom(cc.get());
+            } else {
+                String sharedName = noPrefix.substring(0, 1).toLowerCase().concat(noPrefix.substring(1));
+                Configuration sharedConfig = configurations.findByName(sharedName);
+                if (sharedConfig != null) {
+                    logger.info("Setting configuration '{}' extendsFrom '{}'", specific.getName(), sharedConfig.getName());
+                    specific.extendsFrom(sharedConfig);
+                }
+            }
+        });
 
         // This is only necessary because in real life, we have dependencies between classes
         // and what you're likely to want to do, is to provide a JDK 9 specific class, which depends on common
@@ -146,10 +171,7 @@ public abstract class MultiReleaseExtension {
         Provider<JavaLauncher> targetLauncher = javaToolchains.launcherFor(spec -> spec.getLanguageVersion().convention(jlv));
         logger.info("Setting JavaLauncher toolchain for Java {}: {}", version, jlv);
 
-        Configuration testImplementation = configurations.getByName(testSourceSet.getImplementationConfigurationName());
-        testImplementation.extendsFrom(configurations.getByName(sharedTestSourceSet.getImplementationConfigurationName()));
         Configuration testCompileOnly = configurations.getByName(testSourceSet.getCompileOnlyConfigurationName());
-        testCompileOnly.extendsFrom(configurations.getByName(sharedTestSourceSet.getCompileOnlyConfigurationName()));
         testCompileOnly.getDependencies().add(dependencies.create(langSourceSet.getOutput().getClassesDirs()));
         testCompileOnly.getDependencies().add(dependencies.create(sharedSourceSet.getOutput().getClassesDirs()));
 


### PR DESCRIPTION
**Resolves issue #3:**

The [existing pull request](https://github.com/melix/mrjar-gradle-plugin/pull/10) to resolve this issue assumes the configurations for each Java version should extend from the base "shared" configuration (e.g. `java17CompileClasspath.extendsFrom(compileClasspath)`), but due to the way Multi-Release JARs work, if there are more than two releases to handle, this should instead be, for example:
```
java11CompileClasspath.extendsFrom(compileClasspath)
java17CompileClasspath.extendsFrom(java11CompileClasspath)
java21CompileClasspath.extendsFrom(java17CompileClasspath)
// etc.
```

**Resolves issue #7:**

Modern Java can easily perform cross-version compilation without needing multiple installations by leveraging the _release_ flag. This is now optionally enabled by the `sharedToolchain` flag in the plugin DSL, for example:

```
multiRelease {
    targetVersions 8, 11
    sharedToolchain true
}
```

With this flag enabled, all compilation is performed by the highest version toolchain, but each relevant JavaCompile task has the _release_ flag set for its relevant version.

Also, some convenient logging is added to track what it's doing.